### PR TITLE
Fixed the tutorial of Si

### DIFF
--- a/tutorial/si/gw_bse_si.py
+++ b/tutorial/si/gw_bse_si.py
@@ -44,7 +44,6 @@ os.system('cd gw_bse; %s -F yambo_run.in -J yambo'%yambo)
 
 #creathe the bse input file
 y = YamboIn('%s -b -o b -k sex -y d -V all'%yambo,folder='gw_bse')
-y['QPkrange'] = [QPKrange[:2]+[6,10],'']
 y['FFTGvecs'] = [15,'Ry']
 y['NGsBlkXs'] = [1,'Ry']
 y['BndsRnXs'] = [[1,30],'']

--- a/tutorial/si/gw_bse_si.py
+++ b/tutorial/si/gw_bse_si.py
@@ -23,7 +23,7 @@ if not os.path.isdir('database/SAVE'):
     print('preparing yambo database')
     os.system('cd nscf/si.save; p2y')
     os.system('cd nscf/si.save; yambo')
-    os.system('mv nscf/si.save/SAVE database'.split())
+    os.system('mv nscf/si.save/SAVE database')
 
 if not os.path.isdir('gw_bse'):
     os.mkdir('gw_bse')


### PR DESCRIPTION
Hello.
I found two issues of _gw_bse_si.py_.

1. `os.system('mv nscf/si.save/SAVE database'.split())`
I think `.split()` is not necessary.

2. `y['QPkrange'] = [QPKrange[:2]+[6,10],'']`
I think `yambo -b -o b -k sex -y d -V all` doesn't have QPkrange option.