### PR TITLE
Adding support in the parser for initialize only  runs.

### DIFF
--- a/yamboparser/yambofile.py
+++ b/yamboparser/yambofile.py
@@ -46,6 +46,7 @@ class YamboFile():
         self.kpoints = {}
         self.timing = []
         self.game_over = False  # check yambo run completed successfully
+        self.p2y_complete = False  # check yambo initialization completed successfully
  
         if any(filename.startswith(prefix) for prefix in self._output_prefixes):
             #read lines from file
@@ -172,6 +173,7 @@ class YamboFile():
         memory = re.compile('^\s+?<([0-9a-z-]+)> ([A-Z0-9]+)[:] \[M  ([0-9.]+) Gb\]? ([a-zA-Z0-9\s.()\[\]]+)?')
         timing = re.compile('\s+?[A-Za-z]+iming\s+?[A-Za-z/\[\]]+[:]\s+?([a-z0-9-]+)[/]([a-z0-9-]+)[/]([a-z0-9-]+)')
         game_over = re.compile('^\s+?\[\d+\]\s+?G\w+\s+?O\w+\s+?\&\s+?G\w+\s+?\w+') # Game over & Game summary
+        p2y_complete = re.compile('^(\s+)?[-<>\d\w]+\s+?P\d+[:]\s+?==\s+?P2Y\s+?\w+\s+?==(\s+)?') # P2Y Complete
         self.memstats.extend([ line for line in self.lines if memory.match(line)])
         for line in self.lines:
             if err.match(line):
@@ -186,6 +188,8 @@ class YamboFile():
                 self.kpoints[str(int(kindx))] =  [ float(i.strip()) for i in kpt.split()]
             if game_over.match(line):
                 self.game_over = True
+            if p2y_complete.match(line):
+                self.p2y_complete = True
                     
         full_lines = ''.join(self.lines)
         qp_regx = re.compile('(^\s+?QP\s\[eV\]\s@\sK\s\[\d+\][a-z0-9E:()\s.-]+)(.*?)(?=^$)',re.M|re.DOTALL)


### PR DESCRIPTION
 each yambofile object will provide a .p2y_complete attribute that, for logfiles and only for logfiles will indicate whether the p2y initialization was completed.